### PR TITLE
Add support for `available_capacity_dose1` and `available_capacity_dose2` fields.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>com.abhinav.covid19</groupId>
     <artifactId>covid19-vaccine-tracker</artifactId>
-    <version>0.1.16-SNAPSHOT</version>
+    <version>0.1.17-SNAPSHOT</version>
     <name>covid19-vaccine-tracker</name>
     <description>Demo project for Spring Boot</description>
     <properties>

--- a/src/main/java/org/covid19/vaccinetracker/availability/VaccineAvailability.java
+++ b/src/main/java/org/covid19/vaccinetracker/availability/VaccineAvailability.java
@@ -47,7 +47,7 @@ public class VaccineAvailability {
         Executors.newSingleThreadExecutor().submit(() -> {
             this.refreshVaccineAvailabilityFromCowinViaKafka();
             this.vaccineCentersNotification.checkUpdatesAndSendNotifications();
-            this.pincodeReconciliation.reconcilePincodesFromCowin(userRequestManager.fetchAllUserRequests());
+//            this.pincodeReconciliation.reconcilePincodesFromCowin(userRequestManager.fetchAllUserRequests());
         });
     }
 

--- a/src/main/java/org/covid19/vaccinetracker/availability/VaccineCentersProcessor.java
+++ b/src/main/java/org/covid19/vaccinetracker/availability/VaccineCentersProcessor.java
@@ -25,7 +25,8 @@ public class VaccineCentersProcessor {
     }
 
     public boolean hasCapacity(Session session) {
-        return session.availableCapacityDose1 > 0;
+        return (session.availableCapacityDose1 > 0)
+                && (session.availableCapacity == (session.availableCapacityDose1 + session.availableCapacityDose2));
     }
 
     public boolean ageLimitExactly18(Session session) {

--- a/src/main/java/org/covid19/vaccinetracker/availability/VaccineCentersProcessor.java
+++ b/src/main/java/org/covid19/vaccinetracker/availability/VaccineCentersProcessor.java
@@ -25,7 +25,7 @@ public class VaccineCentersProcessor {
     }
 
     public boolean hasCapacity(Session session) {
-        return session.availableCapacity > 0;
+        return session.availableCapacityDose1 > 0;
     }
 
     public boolean ageLimitExactly18(Session session) {

--- a/src/main/java/org/covid19/vaccinetracker/model/Session.java
+++ b/src/main/java/org/covid19/vaccinetracker/model/Session.java
@@ -23,6 +23,10 @@ public class Session {
     public String date;
     @JsonProperty("available_capacity")
     public Integer availableCapacity;
+    @JsonProperty("available_capacity_dose1")
+    public Integer availableCapacityDose1;
+    @JsonProperty("available_capacity_dose2")
+    public Integer availableCapacityDose2;
     @JsonProperty("min_age_limit")
     public Integer minAgeLimit;
     @JsonProperty("vaccine")

--- a/src/main/java/org/covid19/vaccinetracker/notifications/VaccineCentersNotification.java
+++ b/src/main/java/org/covid19/vaccinetracker/notifications/VaccineCentersNotification.java
@@ -53,11 +53,11 @@ public class VaccineCentersNotification {
         final List<UserRequest> userRequests = userRequestManager.fetchAllUserRequests();
         userRequests.forEach(userRequest -> {
             notificationStats.incrementUserRequests();
-            final String lastNotifiedAt = userRequest.getLastNotifiedAt();
-            if (userWasNotifiedRecently(lastNotifiedAt)) {
-                log.info("Skipping sending notification to {} as they were notified already on {}", userRequest.getChatId(), lastNotifiedAt);
-                return;
-            }
+//            final String lastNotifiedAt = userRequest.getLastNotifiedAt();
+//            if (userWasNotifiedRecently(lastNotifiedAt)) {
+//                log.info("Skipping sending notification to {} as they were notified already on {}", userRequest.getChatId(), lastNotifiedAt);
+//                return;
+//            }
             // process pin codes of each user
             userRequest.getPincodes().forEach(pincode -> {
                 VaccineCenters vaccineCenters;

--- a/src/main/java/org/covid19/vaccinetracker/persistence/mariadb/MariaDBVaccinePersistence.java
+++ b/src/main/java/org/covid19/vaccinetracker/persistence/mariadb/MariaDBVaccinePersistence.java
@@ -23,6 +23,8 @@ import java.util.Set;
 
 import lombok.extern.slf4j.Slf4j;
 
+import static java.util.Objects.nonNull;
+
 @Slf4j
 @Component
 public class MariaDBVaccinePersistence implements VaccinePersistence {
@@ -54,6 +56,8 @@ public class MariaDBVaccinePersistence implements VaccinePersistence {
                     .vaccine(sessionEntity.getVaccine())
                     .date(sessionEntity.getDate())
                     .availableCapacity(sessionEntity.getAvailableCapacity())
+                    .availableCapacityDose1(sessionEntity.getAvailableCapacityDose1())
+                    .availableCapacityDose2(sessionEntity.getAvailableCapacityDose2())
                     .minAgeLimit(sessionEntity.getMinAgeLimit())
                     .build()));
             centers.add(Center.builder()
@@ -94,7 +98,9 @@ public class MariaDBVaccinePersistence implements VaccinePersistence {
                     .id(session.sessionId)
                     .date(session.date)
                     .vaccine(session.vaccine)
-                    .availableCapacity(session.availableCapacity)
+                    .availableCapacity(nonNull(session.availableCapacity) ? session.availableCapacity : 0)
+                    .availableCapacityDose1(nonNull(session.availableCapacityDose1) ? session.availableCapacityDose1 : 0)
+                    .availableCapacityDose2(nonNull(session.availableCapacityDose2) ? session.availableCapacityDose2 : 0)
                     .minAgeLimit(session.minAgeLimit)
                     .processedAt(LocalDateTime.now())
                     .build()));
@@ -111,7 +117,9 @@ public class MariaDBVaccinePersistence implements VaccinePersistence {
                     .id(session.sessionId)
                     .date(session.date)
                     .vaccine(session.vaccine)
-                    .availableCapacity(session.availableCapacity)
+                    .availableCapacity(nonNull(session.availableCapacity) ? session.availableCapacity : 0)
+                    .availableCapacityDose1(nonNull(session.availableCapacityDose1) ? session.availableCapacityDose1 : 0)
+                    .availableCapacityDose2(nonNull(session.availableCapacityDose2) ? session.availableCapacityDose2 : 0)
                     .minAgeLimit(session.minAgeLimit)
                     .processedAt(processedAt)
                     .build()));

--- a/src/main/java/org/covid19/vaccinetracker/persistence/mariadb/entity/SessionEntity.java
+++ b/src/main/java/org/covid19/vaccinetracker/persistence/mariadb/entity/SessionEntity.java
@@ -31,6 +31,12 @@ public class SessionEntity {
     @Column(name = "available_capacity")
     private int availableCapacity;
 
+    @Column(name = "available_capacity_dose1")
+    private int availableCapacityDose1;
+
+    @Column(name = "available_capacity_dose2")
+    private int availableCapacityDose2;
+
     @Column(name = "min_age_limit")
     private int minAgeLimit;
 

--- a/src/main/java/org/covid19/vaccinetracker/reconciliation/PincodeReconciliation.java
+++ b/src/main/java/org/covid19/vaccinetracker/reconciliation/PincodeReconciliation.java
@@ -37,7 +37,7 @@ public class PincodeReconciliation {
         this.botService = botService;
     }
 
-//    @Scheduled(cron = "0 5/10 6-23 * * *", zone = "IST")
+    @Scheduled(cron = "0 0 6-23 * * *", zone = "IST")
     public void pincodesReconciliationJob() {
         this.reconcilePincodesFromCowin(userRequestManager.fetchAllUserRequests());
     }

--- a/src/main/java/org/covid19/vaccinetracker/utils/Utils.java
+++ b/src/main/java/org/covid19/vaccinetracker/utils/Utils.java
@@ -154,8 +154,8 @@ public class Utils {
         for (Center center : eligibleCenters) {
             text.append(String.format("<b>%s (%s %s)</b>\n<pre>\n", center.name, center.districtName, center.pincode));
             for (Session session : center.sessions) {
-                text.append(String.format("%s dose(s) of %s for %s+ age group available on %s ", session.availableCapacity, session.vaccine, session.minAgeLimit, session.date));
-                text.append(String.format(localizedNotificationText(center.getStateName()) + "\n", session.minAgeLimit, session.vaccine, session.availableCapacity, session.date));
+                text.append(String.format("%s dose(s) of %s for %s+ age group available on %s ", session.availableCapacityDose1, session.vaccine, session.minAgeLimit, session.date));
+                text.append(String.format(localizedNotificationText(center.getStateName()) + "\n", session.minAgeLimit, session.vaccine, session.availableCapacityDose1, session.date));
             }
             text.append("</pre>\n");
         }

--- a/src/main/resources/db/migration/V0.1.17.00__sessions_add_dose1_dose2_column.sql
+++ b/src/main/resources/db/migration/V0.1.17.00__sessions_add_dose1_dose2_column.sql
@@ -1,0 +1,9 @@
+SET
+    SQL_MODE = "NO_AUTO_VALUE_ON_ZERO";
+START TRANSACTION;
+SET
+    time_zone = "+00:00";
+
+ALTER TABLE `sessions`
+    ADD COLUMN IF NOT EXISTS `available_capacity_dose1` INT DEFAULT NULL AFTER `available_capacity`,
+    ADD COLUMN IF NOT EXISTS `available_capacity_dose2` INT DEFAULT NULL AFTER `available_capacity_dose1`;

--- a/src/test/java/org/covid19/vaccinetracker/availability/VaccineAvailabilityTest.java
+++ b/src/test/java/org/covid19/vaccinetracker/availability/VaccineAvailabilityTest.java
@@ -103,6 +103,8 @@ public class VaccineAvailabilityTest {
                                         .sessionId("abcd")
                                         .vaccine("COVISHIELD")
                                         .availableCapacity(5)
+                                        .availableCapacityDose1(5) // as most people are looking for 1st dose, this will be used for alerting
+                                        .availableCapacityDose2(0) // ignored for now
                                         .minAgeLimit(18)
                                         .date("15-05-2021")
                                         .build()))

--- a/src/test/java/org/covid19/vaccinetracker/availability/VaccineCentersProcessorTest.java
+++ b/src/test/java/org/covid19/vaccinetracker/availability/VaccineCentersProcessorTest.java
@@ -1,0 +1,42 @@
+package org.covid19.vaccinetracker.availability;
+
+import org.covid19.vaccinetracker.model.Session;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class VaccineCentersProcessorTest {
+    private VaccineCentersProcessor processor;
+
+    @BeforeEach
+    public void setup() {
+        processor = new VaccineCentersProcessor();
+    }
+
+    @Test
+    public void testHasCapacity() {
+        //
+        assertTrue(processor.hasCapacity(Session.builder()
+                .availableCapacity(5)
+                .availableCapacityDose1(5)
+                .availableCapacityDose2(0)
+                .build()),"True if AC=dose1+dose2");
+        assertTrue(processor.hasCapacity(Session.builder()
+                .availableCapacity(8)
+                .availableCapacityDose1(5)
+                .availableCapacityDose2(3)
+                .build()), "True if AC=dose1+dose2");
+        assertFalse(processor.hasCapacity(Session.builder()
+                .availableCapacity(8)
+                .availableCapacityDose1(0)
+                .availableCapacityDose2(0)
+                .build()), "False if dose1 and dose2 are zero");
+        assertFalse(processor.hasCapacity(Session.builder()
+                .availableCapacity(8)
+                .availableCapacityDose1(0)
+                .availableCapacityDose2(8)
+                .build()), "False if dose1 is zero (ignore dose2)");
+    }
+}

--- a/src/test/java/org/covid19/vaccinetracker/utils/UtilsTest.java
+++ b/src/test/java/org/covid19/vaccinetracker/utils/UtilsTest.java
@@ -42,8 +42,8 @@ public class UtilsTest {
                 "For registration, please visit <a href=\"https://selfregistration.cowin.gov.in/\">CoWIN Website</a>\n";
         List<Center> centers = new ArrayList<>();
         List<Session> sessions = new ArrayList<>();
-        sessions.add(Session.builder().availableCapacity(3).minAgeLimit(18).date("04-05-2021").vaccine("COVISHIELD").build());
-        sessions.add(Session.builder().availableCapacity(12).minAgeLimit(18).date("05-05-2021").vaccine("COVAXIN").build());
+        sessions.add(Session.builder().availableCapacity(6).availableCapacityDose1(3).availableCapacityDose2(5).minAgeLimit(18).date("04-05-2021").vaccine("COVISHIELD").build());
+        sessions.add(Session.builder().availableCapacity(4).availableCapacityDose1(12).availableCapacityDose2(3).minAgeLimit(18).date("05-05-2021").vaccine("COVAXIN").build());
         centers.add(Center.builder().name("Premlok Park Disp- 2(18-44)").districtName("Pune").pincode(411033).sessions(sessions).build());
         assertEquals(expected, Utils.buildNotificationMessage(centers), "Notification text does not match");
     }


### PR DESCRIPTION
Use `available_capacity_dose1` to send notifications as CoWIN website uses this field to show availability to authenticated users.