### PR TITLE
Introduce Notifications cache to avoid sending duplicate notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ This repository stores the source code of the Telegram Bot CoWIN Alerts availabl
 
 ![image](https://user-images.githubusercontent.com/4991449/120037514-0cac0600-c002-11eb-86c8-bc63a6c960c0.png)
 
+### Design Goals
+* Send notifications as soon as new Vaccination slots are available.
+* Store critical data (like user requests) in Kafka to achieve RPO = 0
+* Store non-critical data (like Vaccine slots which can be recovered from CoWIN API)
+ outside Kafka to keep costs low.
+
 ## Screenshots
 
 <div>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>com.abhinav.covid19</groupId>
     <artifactId>covid19-vaccine-tracker</artifactId>
-    <version>0.2.6-SNAPSHOT</version>
+    <version>0.2.7-SNAPSHOT</version>
     <name>covid19-vaccine-tracker</name>
     <description>CoWIN Vaccine Alerts</description>
     <properties>

--- a/src/main/java/org/covid19/vaccinetracker/notifications/KafkaNotifications.java
+++ b/src/main/java/org/covid19/vaccinetracker/notifications/KafkaNotifications.java
@@ -83,6 +83,8 @@ public class KafkaNotifications {
                                 stats.incrementNotificationsErrors();
                             }
                             cache.updateUser(user, eligibleCenters);
+                        } else {
+                            log.debug("No difference in slots data since {} was last notified", user);
                         }
                         vaccinePersistence.markProcessed(vaccineCenters); // mark processed
                     }));

--- a/src/main/java/org/covid19/vaccinetracker/notifications/KafkaNotifications.java
+++ b/src/main/java/org/covid19/vaccinetracker/notifications/KafkaNotifications.java
@@ -41,16 +41,18 @@ public class KafkaNotifications {
     private final VaccineCentersProcessor vaccineCentersProcessor;
     private final BotService botService;
     private final NotificationStats stats;
+    private final NotificationCache cache;
 
     public KafkaNotifications(StreamsBuilder streamsBuilder, KTable<String, UsersByPincode> usersByPincodeTable,
                               VaccinePersistence vaccinePersistence, VaccineCentersProcessor vaccineCentersProcessor,
-                              BotService botService, NotificationStats stats) {
+                              BotService botService, NotificationStats stats, NotificationCache cache) {
         this.streamsBuilder = streamsBuilder;
         this.usersByPincodeTable = usersByPincodeTable;
         this.vaccinePersistence = vaccinePersistence;
         this.vaccineCentersProcessor = vaccineCentersProcessor;
         this.botService = botService;
         this.stats = stats;
+        this.cache = cache;
     }
 
     @Bean
@@ -73,10 +75,14 @@ public class KafkaNotifications {
                     .peek(logEmptyCenters(pincode))
                     .filter(eligibleCentersWithData())
                     .forEach(eligibleCenters -> {
-                        if (botService.notify(user, eligibleCenters)) {
-                            stats.incrementNotificationsSent();
-                        } else {
-                            stats.incrementNotificationsErrors();
+                        if (cache.isNewNotification(user, eligibleCenters)) {
+                            log.debug("Slots data changed since {} was last notified", user);
+                            if (botService.notify(user, eligibleCenters)) {
+                                stats.incrementNotificationsSent();
+                            } else {
+                                stats.incrementNotificationsErrors();
+                            }
+                            cache.updateUser(user, eligibleCenters);
                         }
                         vaccinePersistence.markProcessed(vaccineCenters); // mark processed
                     }));

--- a/src/main/java/org/covid19/vaccinetracker/notifications/NotificationCache.java
+++ b/src/main/java/org/covid19/vaccinetracker/notifications/NotificationCache.java
@@ -1,0 +1,67 @@
+package org.covid19.vaccinetracker.notifications;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.apache.commons.codec.digest.DigestUtils;
+import org.covid19.vaccinetracker.model.Center;
+import org.covid19.vaccinetracker.persistence.mariadb.entity.UserNotification;
+import org.covid19.vaccinetracker.persistence.mariadb.repository.UserNotificationRepository;
+import org.jetbrains.annotations.Nullable;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class NotificationCache {
+    private final UserNotificationRepository repository;
+    private final ObjectMapper objectMapper;
+
+    public NotificationCache(UserNotificationRepository repository, ObjectMapper objectMapper) {
+        this.repository = repository;
+        this.objectMapper = objectMapper;
+    }
+
+    public boolean isNewNotification(String user, List<Center> centers) {
+        final Optional<UserNotification> fromCache = this.repository.findById(user);
+
+        if (fromCache.isEmpty()) {
+            return true;
+        }
+
+        byte[] bytes = serialize(centers);
+        if (bytes == null) {
+            return true;
+        }
+
+        return !DigestUtils.sha256Hex(bytes).equals(fromCache.get().getNotificationHash());
+    }
+
+    public void updateUser(String user, List<Center> centers) {
+        byte[] bytes = serialize(centers);
+        String notificationHash = bytes == null ? "unknown" : DigestUtils.sha256Hex(bytes);
+        this.repository.save(
+                UserNotification.builder()
+                        .userId(user)
+                        .notificationHash(notificationHash)
+                        .notifiedAt(LocalDateTime.now())
+                        .build());
+    }
+
+    @Nullable
+    private byte[] serialize(List<Center> centers) {
+        byte[] bytes;
+        try {
+            bytes = objectMapper.writeValueAsBytes(centers);
+        } catch (JsonProcessingException e) {
+            log.error("Error serializing centers {}", centers);
+            return null;
+        }
+        return bytes;
+    }
+}

--- a/src/main/java/org/covid19/vaccinetracker/notifications/VaccineCentersNotification.java
+++ b/src/main/java/org/covid19/vaccinetracker/notifications/VaccineCentersNotification.java
@@ -21,8 +21,10 @@ import lombok.extern.slf4j.Slf4j;
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 
+@SuppressWarnings("DeprecatedIsStillUsed")
 @Slf4j
 @Service
+@Deprecated(forRemoval = true, since = "0.2.7")
 public class VaccineCentersNotification {
     @Value("${users.over45}")
     private List<String> usersOver45;

--- a/src/main/java/org/covid19/vaccinetracker/persistence/mariadb/entity/UserNotification.java
+++ b/src/main/java/org/covid19/vaccinetracker/persistence/mariadb/entity/UserNotification.java
@@ -1,0 +1,34 @@
+package org.covid19.vaccinetracker.persistence.mariadb.entity;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@EqualsAndHashCode
+@Data
+@Builder
+@Entity
+@Table(name = "user_notifications")
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserNotification {
+    @Id
+    @Column(name = "user_id")
+    private String userId;
+
+    @Column(name = "notification_hash")
+    private String notificationHash;
+
+    @Column(name = "notified_at")
+    private LocalDateTime notifiedAt;
+}

--- a/src/main/java/org/covid19/vaccinetracker/persistence/mariadb/repository/UserNotificationRepository.java
+++ b/src/main/java/org/covid19/vaccinetracker/persistence/mariadb/repository/UserNotificationRepository.java
@@ -1,0 +1,9 @@
+package org.covid19.vaccinetracker.persistence.mariadb.repository;
+
+import org.covid19.vaccinetracker.persistence.mariadb.entity.UserNotification;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserNotificationRepository extends JpaRepository<UserNotification, String> {
+}

--- a/src/main/resources/db/migration/V0.2.7.00__add_notification_cache.sql
+++ b/src/main/resources/db/migration/V0.2.7.00__add_notification_cache.sql
@@ -1,0 +1,19 @@
+SET
+SQL_MODE = "NO_AUTO_VALUE_ON_ZERO";
+START TRANSACTION;
+SET
+time_zone = "+00:00";
+
+--
+-- Table structure for table `user_notifications`
+--
+
+CREATE TABLE `user_notifications`
+(
+    `user_id`           varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+    `notification_hash` varchar(255) COLLATE utf8mb4_unicode_ci,
+    `notified_at`       timestamp,
+    PRIMARY KEY (`user_id`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;

--- a/src/test/java/org/covid19/vaccinetracker/notifications/KafkaNotificationsIT.java
+++ b/src/test/java/org/covid19/vaccinetracker/notifications/KafkaNotificationsIT.java
@@ -1,0 +1,166 @@
+package org.covid19.vaccinetracker.notifications;
+
+import org.covid19.vaccinetracker.availability.UpdatedPincodesProducerConfig;
+import org.covid19.vaccinetracker.availability.VaccineCentersProcessor;
+import org.covid19.vaccinetracker.bot.BotService;
+import org.covid19.vaccinetracker.model.Center;
+import org.covid19.vaccinetracker.model.Session;
+import org.covid19.vaccinetracker.model.UserRequest;
+import org.covid19.vaccinetracker.model.VaccineCenters;
+import org.covid19.vaccinetracker.persistence.VaccinePersistence;
+import org.covid19.vaccinetracker.persistence.kafka.KafkaStateStores;
+import org.covid19.vaccinetracker.persistence.kafka.KafkaStreamsConfig;
+import org.covid19.vaccinetracker.userrequests.UserRequestProducerConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.annotation.DirtiesContext;
+
+import java.util.List;
+
+import lombok.extern.slf4j.Slf4j;
+
+import static java.util.Collections.singletonList;
+import static java.util.Objects.nonNull;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@Slf4j
+@SpringBootTest(classes = {
+        UserRequestProducerConfig.class,
+        UpdatedPincodesProducerConfig.class,
+        KafkaProperties.class,
+        KafkaStateStores.class,
+        KafkaStreamsConfig.class,
+        KafkaNotifications.class,
+        VaccineCentersProcessor.class,
+        NotificationStats.class
+})
+@EmbeddedKafka(
+        partitions = 1,
+        topics = {"${topic.user.requests}", "${topic.user.districts}", "${topic.user.bypincode}", "${topic.updated.pincodes}"},
+        brokerProperties = {"listeners=PLAINTEXT://localhost:9092", "port=9092"})
+@DirtiesContext
+public class KafkaNotificationsIT {
+    @Value("${topic.user.requests}")
+    private String userRequestsTopic;
+
+    @Value("${topic.updated.pincodes}")
+    private String updatedPincodesTopic;
+
+    @MockBean
+    private VaccinePersistence vaccinePersistence;
+
+    @MockBean
+    private NotificationCache cache;
+
+    @MockBean
+    private BotService botService;
+
+    @Autowired
+    private NotificationStats stats;
+
+    @Autowired
+    private KafkaStateStores stateStores;
+
+    @Autowired
+    private KafkaTemplate<String, String> updatedPincodesKafkaTemplate;
+
+    @Autowired
+    private KafkaTemplate<String, UserRequest> userRequestKafkaTemplate;
+
+    @BeforeEach
+    public void setup() {
+        userRequestKafkaTemplate.send(userRequestsTopic, "userA", new UserRequest("userA", List.of("110022"), null));
+        userRequestKafkaTemplate.send(userRequestsTopic, "userB", new UserRequest("userB", List.of("110023"), null));
+    }
+
+    @Test
+    public void testNotificationsStream_withEligibleCenters_notificationSent() {
+        // allow usersByPincode stream to be updated from setup()
+        await().atMost(2L, SECONDS).until(() -> nonNull(stateStores.usersByPincode("110022")));
+
+        final VaccineCenters data = createCentersWithData();
+        when(vaccinePersistence.fetchVaccineCentersByPincode("110022")).thenReturn(data);
+        when(cache.isNewNotification(anyString(), any())).thenReturn(true);
+        when(botService.notify(anyString(), any())).thenReturn(true);
+
+        updatedPincodesKafkaTemplate.send(updatedPincodesTopic, "110022", "110022");
+
+        await().atMost(2L, SECONDS).until(() -> stats.notificationsSent() >= 1);
+
+        verify(botService, times(1)).notify(anyString(), any());
+        verify(cache, times(1)).updateUser(anyString(), any());
+        verify(vaccinePersistence, times(1)).markProcessed(data);
+    }
+
+    @Test
+    public void testNotificationsStream_withoutEligibleCenters_notificationNotSent() {
+        // allow usersByPincode stream to be updated from setup()
+        await().atMost(2L, SECONDS).until(() -> nonNull(stateStores.usersByPincode("110023")));
+
+        final VaccineCenters data = createCentersWithoutData();
+        when(vaccinePersistence.fetchVaccineCentersByPincode("110023")).thenReturn(data);
+        when(cache.isNewNotification(anyString(), any())).thenReturn(true);
+        when(botService.notify(anyString(), any())).thenReturn(true);
+
+        updatedPincodesKafkaTemplate.send(updatedPincodesTopic, "110023", "110023");
+
+        verify(botService, times(0)).notify(anyString(), any());
+        verify(cache, times(0)).updateUser(anyString(), any());
+        verify(vaccinePersistence, times(0)).markProcessed(data);
+    }
+
+    private VaccineCenters createCentersWithData() {
+        return new VaccineCenters(List.of(
+                Center.builder()
+                        .centerId(123)
+                        .name("RAJIV GANDHI SUPER SPECIALITY")
+                        .pincode(110022)
+                        .districtName("Shahdara")
+                        .stateName("Delhi")
+                        .sessions(singletonList(
+                                Session.builder()
+                                        .sessionId("abcd")
+                                        .vaccine("COVISHIELD")
+                                        .availableCapacity(5)
+                                        .availableCapacityDose1(5)
+                                        .availableCapacityDose2(0)
+                                        .minAgeLimit(18)
+                                        .date("15-05-2021")
+                                        .build()))
+                        .build()));
+    }
+
+    private VaccineCenters createCentersWithoutData() {
+        return new VaccineCenters(List.of(
+                Center.builder()
+                        .centerId(123)
+                        .name("RAJIV GANDHI SUPER SPECIALITY")
+                        .pincode(110093)
+                        .districtName("Shahdara")
+                        .stateName("Delhi")
+                        .sessions(singletonList(
+                                Session.builder()
+                                        .sessionId("abcd")
+                                        .vaccine("COVISHIELD")
+                                        .availableCapacity(0)
+                                        .availableCapacityDose1(0)
+                                        .availableCapacityDose2(0)
+                                        .minAgeLimit(18)
+                                        .date("15-05-2021")
+                                        .build()))
+                        .build()));
+    }
+}

--- a/src/test/java/org/covid19/vaccinetracker/notifications/NotificationCacheTest.java
+++ b/src/test/java/org/covid19/vaccinetracker/notifications/NotificationCacheTest.java
@@ -1,0 +1,77 @@
+package org.covid19.vaccinetracker.notifications;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.apache.commons.codec.digest.DigestUtils;
+import org.covid19.vaccinetracker.model.Center;
+import org.covid19.vaccinetracker.model.Session;
+import org.covid19.vaccinetracker.persistence.mariadb.entity.UserNotification;
+import org.covid19.vaccinetracker.persistence.mariadb.repository.UserNotificationRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DataJpaTest
+public class NotificationCacheTest {
+    @Autowired
+    private UserNotificationRepository repository;
+
+    private NotificationCache cache;
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    public void setup() {
+        objectMapper = new ObjectMapper();
+        this.cache = new NotificationCache(repository, objectMapper);
+    }
+
+    @Test
+    public void testNewNotification() throws Exception {
+        List<Center> old = List.of(Center.builder().centerId(123).name("abc")
+                .sessions(List.of(Session.builder()
+                        .availableCapacity(10)
+                        .availableCapacityDose1(10)
+                        .build()))
+                .build());
+        this.repository.save(UserNotification.builder()
+                .userId("userA")
+                .notificationHash(DigestUtils.sha256Hex(objectMapper.writeValueAsBytes(old)))
+                .build());
+
+        List<Center> updated = List.of(Center.builder().centerId(123).name("abc")
+                .sessions(List.of(Session.builder()
+                        .availableCapacity(5)   // capacity changed
+                        .availableCapacityDose1(5)
+                        .build()))
+                .build());
+
+        assertTrue(cache.isNewNotification("userA", updated));
+    }
+
+    @Test
+    public void testOldNotification() throws Exception {
+        List<Center> old = List.of(Center.builder().centerId(123).name("abc")
+                .sessions(List.of(Session.builder()
+                        .availableCapacity(10)
+                        .availableCapacityDose1(10)
+                        .build()))
+                .build());
+        this.repository.save(UserNotification.builder()
+                .userId("userA")
+                .notificationHash(DigestUtils.sha256Hex(objectMapper.writeValueAsBytes(old)))
+                .build());
+
+        assertFalse(cache.isNewNotification("userA", old));
+    }
+
+    @Test
+    public void testNewNotificationWhenFirstTime() {
+        assertTrue(cache.isNewNotification("userA", List.of()));
+    }
+}

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -9,6 +9,7 @@ topic:
   user.requests: "user-requests"
   user.districts: "user-districts"
   user.bypincode: "users-by-pincode"
+  updated.pincodes: "updated-pincodes"
 
 spring:
   flyway:
@@ -22,3 +23,7 @@ spring:
       hibernate:
         hbm2ddl:
           import_files_sql_extractor: org.hibernate.tool.hbm2ddl.MultipleLinesSqlCommandExtractor
+
+logging:
+  level:
+    org.covid19.vaccinetracker: DEBUG


### PR DESCRIPTION
Closes #28 

Perform a SHA256 hash of last notification sent to each user in local cache (DB), check new updates in cache and send notifications only if hashes don't match.