### PR TITLE
Create docker image for both amd64 and arm64 platforms.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,16 @@
                 <configuration>
                     <from>
                         <image>openjdk:11-jre</image>
+                        <platforms>
+                            <platform>
+                                <architecture>amd64</architecture>
+                                <os>linux</os>
+                            </platform>
+                            <platform>
+                                <architecture>arm64</architecture>
+                                <os>linux</os>
+                            </platform>
+                        </platforms>
                     </from>
                     <to>
                         <image>xsreality/${project.artifactId}:${project.version}


### PR DESCRIPTION
Closes #41 

Switch from AMD to ARM EC2 Graviton machine to save over 40% in costs.