### PR TITLE
Send notifications only when fresh slots are opened for a Center

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>com.abhinav.covid19</groupId>
     <artifactId>covid19-vaccine-tracker</artifactId>
-    <version>0.2.27-SNAPSHOT</version>
+    <version>0.2.28-SNAPSHOT</version>
     <name>covid19-vaccine-tracker</name>
     <description>CoWIN Vaccine Alerts</description>
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>com.abhinav.covid19</groupId>
     <artifactId>covid19-vaccine-tracker</artifactId>
-    <version>0.2.28-SNAPSHOT</version>
+    <version>0.2.29-SNAPSHOT</version>
     <name>covid19-vaccine-tracker</name>
     <description>CoWIN Vaccine Alerts</description>
     <properties>

--- a/src/main/java/org/covid19/vaccinetracker/model/Session.java
+++ b/src/main/java/org/covid19/vaccinetracker/model/Session.java
@@ -1,9 +1,8 @@
 package org.covid19.vaccinetracker.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
-import org.covid19.vaccinetracker.userrequests.model.Vaccine;
 
 import java.util.List;
 
@@ -39,6 +38,8 @@ public class Session {
     public String vaccine;
     @JsonProperty("slots")
     public List<String> slots = null;
+    @JsonIgnore
+    public boolean shouldNotify = true;
 
     public boolean ageLimit18AndAbove() {
         return minAgeLimit >= 18;

--- a/src/main/java/org/covid19/vaccinetracker/notifications/NotificationCache.java
+++ b/src/main/java/org/covid19/vaccinetracker/notifications/NotificationCache.java
@@ -50,8 +50,8 @@ public class NotificationCache {
         }
 
         // obtain "last notified at" in IST zone
-        String lastNotifiedAt = ZonedDateTime.of(fromCache.get().getNotifiedAt(), ZoneId.of("UTC")).withZoneSameInstant(ZoneId.of(INDIA_TIMEZONE)).format(Utils.dtf);
-        return !DigestUtils.sha256Hex(bytes).equals(fromCache.get().getNotificationHash()) && Utils.past15mins(lastNotifiedAt);
+//        String lastNotifiedAt = ZonedDateTime.of(fromCache.get().getNotifiedAt(), ZoneId.of("UTC")).withZoneSameInstant(ZoneId.of(INDIA_TIMEZONE)).format(Utils.dtf);
+        return !DigestUtils.sha256Hex(bytes).equals(fromCache.get().getNotificationHash());
     }
 
     public void updateUser(String user, String pincode, List<Center> centers) {

--- a/src/main/java/org/covid19/vaccinetracker/persistence/VaccinePersistence.java
+++ b/src/main/java/org/covid19/vaccinetracker/persistence/VaccinePersistence.java
@@ -1,6 +1,9 @@
 package org.covid19.vaccinetracker.persistence;
 
 import org.covid19.vaccinetracker.model.VaccineCenters;
+import org.covid19.vaccinetracker.persistence.mariadb.entity.SessionEntity;
+
+import java.util.Optional;
 
 public interface VaccinePersistence {
     void persistVaccineCenters(VaccineCenters vaccineCenters);
@@ -10,4 +13,6 @@ public interface VaccinePersistence {
     void markProcessed(VaccineCenters vaccineCenters);
 
     void cleanupOldCenters(String date);
+
+    Optional<SessionEntity> findLatestSession(Long centerId, String date, Integer age, String vaccine);
 }

--- a/src/main/java/org/covid19/vaccinetracker/persistence/VaccinePersistence.java
+++ b/src/main/java/org/covid19/vaccinetracker/persistence/VaccinePersistence.java
@@ -14,5 +14,5 @@ public interface VaccinePersistence {
 
     void cleanupOldCenters(String date);
 
-    Optional<SessionEntity> findLatestSession(Long centerId, String date, Integer age, String vaccine);
+    Optional<SessionEntity> findExistingSession(Long centerId, String date, Integer age, String vaccine);
 }

--- a/src/main/java/org/covid19/vaccinetracker/persistence/mariadb/MariaDBVaccinePersistence.java
+++ b/src/main/java/org/covid19/vaccinetracker/persistence/mariadb/MariaDBVaccinePersistence.java
@@ -16,6 +16,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import lombok.extern.slf4j.Slf4j;
@@ -123,5 +124,12 @@ public class MariaDBVaccinePersistence implements VaccinePersistence {
     @Override
     public void cleanupOldCenters(String date) {
         this.centerRepository.deleteBySessionsDate(date);
+    }
+
+    @Override
+    public Optional<SessionEntity> findLatestSession(Long centerId, String date, Integer age, String vaccine) {
+        return sessionRepository.findLatestSession(centerId, date, age, vaccine)
+                .stream()
+                .findFirst();
     }
 }

--- a/src/main/java/org/covid19/vaccinetracker/persistence/mariadb/MariaDBVaccinePersistence.java
+++ b/src/main/java/org/covid19/vaccinetracker/persistence/mariadb/MariaDBVaccinePersistence.java
@@ -104,7 +104,7 @@ public class MariaDBVaccinePersistence implements VaccinePersistence {
                     .availableCapacityDose1(nonNull(session.availableCapacityDose1) ? session.availableCapacityDose1 : 0)
                     .availableCapacityDose2(nonNull(session.availableCapacityDose2) ? session.availableCapacityDose2 : 0)
                     .minAgeLimit(session.minAgeLimit)
-                    .processedAt(processedAt)
+                    .processedAt(session.shouldNotify ? processedAt : LocalDateTime.now())
                     .build()));
             sessionRepository.saveAll(sessionEntities);
             centerEntities.add(CenterEntity.builder()
@@ -127,7 +127,7 @@ public class MariaDBVaccinePersistence implements VaccinePersistence {
     }
 
     @Override
-    public Optional<SessionEntity> findLatestSession(Long centerId, String date, Integer age, String vaccine) {
+    public Optional<SessionEntity> findExistingSession(Long centerId, String date, Integer age, String vaccine) {
         return sessionRepository.findLatestSession(centerId, date, age, vaccine)
                 .stream()
                 .findFirst();

--- a/src/main/java/org/covid19/vaccinetracker/persistence/mariadb/entity/SessionEntity.java
+++ b/src/main/java/org/covid19/vaccinetracker/persistence/mariadb/entity/SessionEntity.java
@@ -15,7 +15,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
-@EqualsAndHashCode
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @Builder
 @Data
 @Entity
@@ -24,6 +24,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SessionEntity {
+    @EqualsAndHashCode.Include
     @Id
     private String id;
 

--- a/src/main/java/org/covid19/vaccinetracker/persistence/mariadb/repository/SessionRepository.java
+++ b/src/main/java/org/covid19/vaccinetracker/persistence/mariadb/repository/SessionRepository.java
@@ -2,9 +2,18 @@ package org.covid19.vaccinetracker.persistence.mariadb.repository;
 
 import org.covid19.vaccinetracker.persistence.mariadb.entity.SessionEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface SessionRepository extends JpaRepository<SessionEntity, String> {
+    @Query("SELECT s FROM CenterEntity c " +
+            "JOIN c.sessions s " +
+            "WHERE c.id = :centerId " +
+            "AND s.date = :date " +
+            "AND s.minAgeLimit = :age " +
+            "AND s.vaccine = :vaccine ")
+    List<SessionEntity> findLatestSession(Long centerId, String date, Integer age, String vaccine);
 }

--- a/src/test/java/org/covid19/vaccinetracker/availability/aws/CowinLambdaWrapperTest.java
+++ b/src/test/java/org/covid19/vaccinetracker/availability/aws/CowinLambdaWrapperTest.java
@@ -1,0 +1,102 @@
+package org.covid19.vaccinetracker.availability.aws;
+
+import com.amazonaws.services.lambda.AWSLambda;
+import com.amazonaws.services.lambda.AWSLambdaAsync;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.covid19.vaccinetracker.model.Center;
+import org.covid19.vaccinetracker.model.Session;
+import org.covid19.vaccinetracker.model.VaccineCenters;
+import org.covid19.vaccinetracker.persistence.VaccinePersistence;
+import org.covid19.vaccinetracker.persistence.mariadb.entity.SessionEntity;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.KafkaTemplate;
+
+import java.util.Optional;
+
+import static java.util.Collections.singletonList;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+public class CowinLambdaWrapperTest {
+    @Mock
+    private AWSConfig awsConfig;
+    @Mock
+    private AWSLambda awsLambda;
+    @Mock
+    private AWSLambdaAsync awsLambdaAsync;
+    @Mock
+    private ObjectMapper objectMapper;
+    @Mock
+    private VaccinePersistence vaccinePersistence;
+    @Mock
+    private KafkaTemplate<String, String> kafkaTemplate;
+
+    @Test
+    public void testFreshAvailabilityWithFreshSlots() {
+        CowinLambdaWrapper lambdaWrapper = new CowinLambdaWrapper(awsConfig, awsLambda, awsLambdaAsync,
+                objectMapper, vaccinePersistence, kafkaTemplate);
+        Mockito.when(vaccinePersistence.findExistingSession(1205L, "22-05-2021", 18, "COVAXIN"))
+                .thenReturn(Optional.of(SessionEntity.builder()
+                        .id("32bbb37e-7cb4-4942-bd92-ac56d86490f9")
+                        .vaccine("COVAXIN")
+                        .availableCapacity(10)
+                        .availableCapacityDose1(10)
+                        .availableCapacityDose2(0)
+                        .minAgeLimit(18)
+                        .build()));
+        final VaccineCenters actual = lambdaWrapper.freshAvailability(buildVaccineCenters());
+        assertThat(actual.getCenters().size(), is(1));
+        assertThat(actual.getCenters().get(0).getSessions().size(), is(1));
+        assertThat(actual.getCenters().get(0).getSessions().get(0).isShouldNotify(), is(true));
+    }
+
+    @Test
+    public void testFreshAvailabilityNoFreshSlots() {
+        CowinLambdaWrapper lambdaWrapper = new CowinLambdaWrapper(awsConfig, awsLambda, awsLambdaAsync,
+                objectMapper, vaccinePersistence, kafkaTemplate);
+        Mockito.when(vaccinePersistence.findExistingSession(1205L, "22-05-2021", 18, "COVAXIN"))
+                .thenReturn(Optional.of(SessionEntity.builder()
+                        .id("32bbb37e-7cb4-4942-bd92-ac56d86490f9")
+                        .vaccine("COVAXIN")
+                        .availableCapacity(30)
+                        .availableCapacityDose1(30)
+                        .availableCapacityDose2(0)
+                        .minAgeLimit(18)
+                        .build()));
+        final VaccineCenters actual = lambdaWrapper.freshAvailability(buildVaccineCenters());
+        assertThat(actual.getCenters().size(), is(1));
+        assertThat(actual.getCenters().get(0).getSessions().size(), is(1));
+        assertThat(actual.getCenters().get(0).getSessions().get(0).isShouldNotify(), is(false));
+    }
+
+    @NotNull
+    private VaccineCenters buildVaccineCenters() {
+        final VaccineCenters vaccineCenters = new VaccineCenters();
+        vaccineCenters.setCenters(
+                singletonList(Center.builder()
+                        .centerId(1205)
+                        .name("Mohalla Clinic Peeragarhi PHC")
+                        .stateName("Delhi")
+                        .districtName("West Delhi")
+                        .pincode(110056)
+                        .feeType("Free")
+                        .sessions(singletonList(Session.builder()
+                                .sessionId("32bbb37e-7cb4-4942-bd92-ac56d86490f9")
+                                .date("22-05-2021")
+                                .availableCapacity(15)
+                                .availableCapacityDose1(15)
+                                .availableCapacityDose2(0)
+                                .minAgeLimit(18)
+                                .vaccine("COVAXIN")
+                                .build()))
+                        .build()));
+        return vaccineCenters;
+    }
+}

--- a/src/test/java/org/covid19/vaccinetracker/availability/aws/CowinLambdaWrapperTest.java
+++ b/src/test/java/org/covid19/vaccinetracker/availability/aws/CowinLambdaWrapperTest.java
@@ -76,6 +76,28 @@ public class CowinLambdaWrapperTest {
         assertThat(actual.getCenters().get(0).getSessions().get(0).isShouldNotify(), is(false));
     }
 
+    /*
+     * Cancellation is when available capacity increases by 1 or 2 slots only.
+     */
+    @Test
+    public void testFreshAvailabilityWithCancellations() {
+        CowinLambdaWrapper lambdaWrapper = new CowinLambdaWrapper(awsConfig, awsLambda, awsLambdaAsync,
+                objectMapper, vaccinePersistence, kafkaTemplate);
+        Mockito.when(vaccinePersistence.findExistingSession(1205L, "22-05-2021", 18, "COVAXIN"))
+                .thenReturn(Optional.of(SessionEntity.builder()
+                        .id("32bbb37e-7cb4-4942-bd92-ac56d86490f9")
+                        .vaccine("COVAXIN")
+                        .availableCapacity(13)
+                        .availableCapacityDose1(13)
+                        .availableCapacityDose2(0)
+                        .minAgeLimit(18)
+                        .build()));
+        final VaccineCenters actual = lambdaWrapper.freshAvailability(buildVaccineCenters());
+        assertThat(actual.getCenters().size(), is(1));
+        assertThat(actual.getCenters().get(0).getSessions().size(), is(1));
+        assertThat(actual.getCenters().get(0).getSessions().get(0).isShouldNotify(), is(false));
+    }
+
     @NotNull
     private VaccineCenters buildVaccineCenters() {
         final VaccineCenters vaccineCenters = new VaccineCenters();

--- a/src/test/java/org/covid19/vaccinetracker/notifications/NotificationCacheTest.java
+++ b/src/test/java/org/covid19/vaccinetracker/notifications/NotificationCacheTest.java
@@ -9,6 +9,7 @@ import org.covid19.vaccinetracker.persistence.mariadb.entity.UserNotification;
 import org.covid19.vaccinetracker.persistence.mariadb.entity.UserNotificationId;
 import org.covid19.vaccinetracker.persistence.mariadb.repository.UserNotificationRepository;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -88,6 +89,7 @@ public class NotificationCacheTest {
         assertTrue(cache.isNewNotification("userA", "110022", List.of()));
     }
 
+    @Disabled
     @Test
     public void testNotificationLastNotifiedAtWithin15Mins() throws Exception {
         List<Center> old = List.of(Center.builder().centerId(123).name("abc")

--- a/src/test/java/org/covid19/vaccinetracker/persistence/mariadb/MariaDBVaccinePersistenceTest.java
+++ b/src/test/java/org/covid19/vaccinetracker/persistence/mariadb/MariaDBVaccinePersistenceTest.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -79,6 +80,19 @@ public class MariaDBVaccinePersistenceTest {
         vaccinePersistence.persistVaccineCenters(vaccineCenters);
         assertTrue(sessionRepository.findById("32bbb37e-7cb4-4942-bd92-ac56d86490f9").isPresent());
         assertTrue(centerRepository.findById(1205L).isPresent());
+    }
+
+    @Test
+    public void testFindLatestSession() {
+        vaccinePersistence.persistVaccineCenters(buildVaccineCenters());
+        final Optional<SessionEntity> session = vaccinePersistence.findLatestSession(1205L, "22-05-2021", 18, "COVAXIN");
+        assertTrue(session.isPresent());
+        assertEquals("22-05-2021", session.get().getDate());
+        assertEquals(18, session.get().getMinAgeLimit());
+        assertEquals("COVAXIN", session.get().getVaccine());
+
+        final Optional<SessionEntity> shouldNotExist = vaccinePersistence.findLatestSession(1205L, "23-05-2021", 18, "COVAXIN");
+        assertFalse(shouldNotExist.isPresent());
     }
 
     @NotNull

--- a/src/test/java/org/covid19/vaccinetracker/persistence/mariadb/MariaDBVaccinePersistenceTest.java
+++ b/src/test/java/org/covid19/vaccinetracker/persistence/mariadb/MariaDBVaccinePersistenceTest.java
@@ -85,13 +85,13 @@ public class MariaDBVaccinePersistenceTest {
     @Test
     public void testFindLatestSession() {
         vaccinePersistence.persistVaccineCenters(buildVaccineCenters());
-        final Optional<SessionEntity> session = vaccinePersistence.findLatestSession(1205L, "22-05-2021", 18, "COVAXIN");
+        final Optional<SessionEntity> session = vaccinePersistence.findExistingSession(1205L, "22-05-2021", 18, "COVAXIN");
         assertTrue(session.isPresent());
         assertEquals("22-05-2021", session.get().getDate());
         assertEquals(18, session.get().getMinAgeLimit());
         assertEquals("COVAXIN", session.get().getVaccine());
 
-        final Optional<SessionEntity> shouldNotExist = vaccinePersistence.findLatestSession(1205L, "23-05-2021", 18, "COVAXIN");
+        final Optional<SessionEntity> shouldNotExist = vaccinePersistence.findExistingSession(1205L, "23-05-2021", 18, "COVAXIN");
         assertFalse(shouldNotExist.isPresent());
     }
 


### PR DESCRIPTION
"Fresh Slots" are slots that are opened in a bunch together. Identified by comparing new slots with the last known count.

Check existing Session data for a Center and if new data has higher capacity then existing data then consider this as fresh availability valid for notifications. This is based on the assumption that as slots are booked capacity will keep reducing so will always be lower than existing data in DB.